### PR TITLE
Improve the formatting of advisory descriptions

### DIFF
--- a/_layouts/advisory.html
+++ b/_layouts/advisory.html
@@ -60,4 +60,4 @@ layout: post
 
 <h3>DESCRIPTION</h3>
 
-<p>{{ page.advisory.description }}</p>
+<div class="advisory-description">{{ page.advisory.description }}</div>

--- a/assets/bootstrap/css/custom.css
+++ b/assets/bootstrap/css/custom.css
@@ -839,3 +839,9 @@ form.well {
 .tooltip-inner {
 	max-width: 500px;
 }
+
+
+/* ADVISORY DESCRIPTION */
+.advisory-description {
+    white-space: pre-line;
+}


### PR DESCRIPTION
A simple attempt of fixing the formatting of the advisory descriptions.
Markdown is not rendered which would be nice.

Left side: current version
Right side: formatted version

![image](https://cloud.githubusercontent.com/assets/164718/13652310/c00e5dce-e64b-11e5-83cb-afb41fb24cca.png)

Let me know if something needs to be adjusted. 
