### PR TITLE
Add On GitHub button to Get Updates header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,3 +32,5 @@ titlecase: true       # Converts page and post titles to titlecase
 
 twitter_user: rubysec
 twitter_tweet_button: true
+
+github_repo: rubysec/rubysec.github.io

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,6 +9,10 @@
       {% if site.twitter_user %}
       <td><a href="https://twitter.com/{{site.twitter_user}}" class="btn"><i class="icon-twitter-sign"></i> On Twitter</a></td>
       {% endif %}
+      <td>&nbsp;</td>
+      {% if site.github_repo %}
+      <td><a href="https://github.com/{{site.github_repo}}" class="btn"><i class="icon-github-sign"></i> On GitHub</a></td>
+      {% endif %}
     </tr>
   </table>
 </div>


### PR DESCRIPTION
Add On GitHub button:

- Can get updates via GitHub watch button
- As a way to show this site's source repository

<img width="473" alt="screenshot 2016-03-12 15 56 04" src="https://cloud.githubusercontent.com/assets/1000669/13721747/f06de9b4-e86a-11e5-8825-c1f6cf7b34d7.png">
